### PR TITLE
Fix $*ENV and add check for existing variable

### DIFF
--- a/lib/File/Which.pm6
+++ b/lib/File/Which.pm6
@@ -44,7 +44,7 @@ module File::Which {
 
     # check for aliases first
     if IS_MAC {
-      my @aliases = $*ENV<Aliases>.split( ',' );
+      my @aliases = %*ENV<Aliases>:exists ?? %*ENV<Aliases>.split( ',' ) !! ();
       for @aliases -> $alias {
         # This has not been tested!!
         # PPT which says MPW-Perl cannot resolve `Alias $alias`,


### PR DESCRIPTION
On Mac, $*ENV is currently breaking.  Looks like it was changed to %*ENV.  On my Mac, Aliases isn't set.  Added a check to see if it exists.