### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
   "name"         : "File::Which",
+  "license"      : "MIT",
   "version"      : "*",
   "perl"         : "6.c",
   "description"  : "Cross platform Perl 6 executable path finder (aka which on UNIX)",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license