### PR TITLE
Make test on window versions with wordpad app

### DIFF
--- a/t/02-win32.t
+++ b/t/02-win32.t
@@ -3,7 +3,7 @@ use v6;
 use Test;
 use File::Which;
 
-my @execs = ('calc', 'cmd', 'explorer', 'wordpad', 'notepad');
+my @execs = ('calc', 'cmd', 'explorer', 'notepad');
 
 plan @execs.elems * 2;
 


### PR DESCRIPTION
Windows 11 does not contain wordpad. Test checking for presence of wordpad was failing.