### PR TITLE
only return results if there are any

### DIFF
--- a/examples/01-which.pl6
+++ b/examples/01-which.pl6
@@ -6,5 +6,7 @@ use File::Which;
 # All perl executables in PATH
 say which('perl6', :all);
 
+say which('zzzaaa123', :all);
+
 # First executable in PATH
 say which('perl6');

--- a/lib/File/Which/Win32.pm6
+++ b/lib/File/Which/Win32.pm6
@@ -45,7 +45,7 @@ method which(Str $exec, Bool :$all = False) {
     }
   }
 
-  return @results.unique if $all;
+  return @results.unique if $all && @results;
   # Fallback to using win32 API to find executable location
   return self.which-win32-api($exec);
 }


### PR DESCRIPTION
If I understand how this module works under windows, it seems the registry check for a command will be skipped if there are no results and all results are desired. This would seem to be a bug. 